### PR TITLE
Increase bottom padding for code block caption

### DIFF
--- a/CHANGES/3.bugfix
+++ b/CHANGES/3.bugfix
@@ -1,0 +1,1 @@
+Increase bottom padding for code block caption to avoid it overlapping with the code block.

--- a/aiohttp_theme/static/aiohttp.css_t
+++ b/aiohttp_theme/static/aiohttp.css_t
@@ -730,3 +730,7 @@ table.docutils.citation, table.docutils.citation td, table.docutils.citation th 
   -webkit-box-shadow: none;
   box-shadow: none;
 }
+
+div.code-block-caption {
+    padding: 2px 5px 10px;
+}


### PR DESCRIPTION
Closes #3.

## What do these changes do?

Increase the bottom padding for the code block caption div to avoid it overlapping with the code block. See #3 for more details.

## Are there changes in behavior for the user?

No.

## Related issue number

#3

## Checklist

- [x] I think the code is well written
- [ ] ~Unit tests for the changes exist~ - no tests found
- [ ] ~Documentation reflects the changes~ - looks like these are `alabaster` docs, so no changes
- [x] Add a new news fragment into the `CHANGES` folder