### PR TITLE
Remove margin rule

### DIFF
--- a/aiohttp_theme/static/aiohttp.css_t
+++ b/aiohttp_theme/static/aiohttp.css_t
@@ -300,10 +300,6 @@ div.admonition p.last {
 }
 
 
-div[class^="highlight-"] {
-    margin-top: -10px;
-}
-
 div.highlight {
     background-color: {{ theme_code_highlight_bg }};
 }


### PR DESCRIPTION
Seems to screw up the code sections in the parameters list in recent versions of sphinx. This rule pulls the code block up, while the paragraphs in the params list get a `margin: 0` rule causing them to overlap. Format still looks fine with the little extra spacing before the code block elsewhere (whereas restoring the margin on the param paragraphs looks pretty bad).

Fixes #62. Seems this has caused issues in the past, so this also fixes #25.